### PR TITLE
Add page to view past embeds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Pricing from "./pages/Pricing";
 import NotFound from "./pages/NotFound";
+import PastEmbeds from "./pages/PastEmbeds";
 
 const queryClient = new QueryClient();
 
@@ -22,6 +23,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/login" element={<Login />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/embeds" element={<PastEmbeds />} />
           <Route path="/pricing" element={<Pricing />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -127,6 +127,17 @@ const Dashboard = () => {
     setEmbedCode(embedHtml);
     setEmbedCount(prev => prev + 1);
     setShowPreview(true);
+
+    try {
+      const stored = JSON.parse(localStorage.getItem("embeds") || "[]");
+      stored.unshift({ url: videoUrl, code: embedHtml, date: new Date().toISOString() });
+      localStorage.setItem("embeds", JSON.stringify(stored.slice(0, 50)));
+    } catch {
+      localStorage.setItem(
+        "embeds",
+        JSON.stringify([{ url: videoUrl, code: embedHtml, date: new Date().toISOString() }])
+      );
+    }
   };
 
   const copyToClipboard = () => {
@@ -216,6 +227,9 @@ const Dashboard = () => {
             </span>
             {embedCount}/10 embeds used
           </div>
+          <Button variant="outline" size="sm" asChild>
+            <a href="/embeds">Past Embeds</a>
+          </Button>
           <Button variant="default" size="sm">Upgrade Pro</Button>
         </div>
       </header>

--- a/src/pages/PastEmbeds.tsx
+++ b/src/pages/PastEmbeds.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { ArrowLeft, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface SavedEmbed {
+  url: string;
+  code: string;
+  date: string;
+}
+
+const PastEmbeds = () => {
+  const [embeds, setEmbeds] = useState<SavedEmbed[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("embeds");
+    if (stored) {
+      try {
+        setEmbeds(JSON.parse(stored));
+      } catch {
+        setEmbeds([]);
+      }
+    }
+  }, []);
+
+  const copyCode = (code: string) => {
+    navigator.clipboard.writeText(code);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <header className="flex justify-between items-center p-4 border-b border-gray-800">
+        <div className="flex items-center gap-4">
+          <a
+            href="/"
+            className="flex items-center gap-2 text-sm text-gray-400 hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Home
+          </a>
+          <div className="w-px h-6 bg-gray-800" />
+          <h1 className="text-xl font-semibold">Past Embeds</h1>
+        </div>
+        <Button variant="outline" size="sm" asChild>
+          <a href="/dashboard">Back to Generator</a>
+        </Button>
+      </header>
+      <main className="p-6">
+        {embeds.length === 0 ? (
+          <p className="text-center text-gray-400">No embeds yet.</p>
+        ) : (
+          <Table className="bg-gray-800/50 rounded-lg">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>URL</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {embeds.map((e, i) => (
+                <TableRow key={i}>
+                  <TableCell>{new Date(e.date).toLocaleString()}</TableCell>
+                  <TableCell className="break-all">{e.url}</TableCell>
+                  <TableCell className="text-right">
+                    <Button variant="ghost" size="sm" onClick={() => copyCode(e.code)}>
+                      <Copy className="w-4 h-4 mr-2" />Copy
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default PastEmbeds;


### PR DESCRIPTION
## Summary
- save generated embed codes in localStorage
- add Past Embeds page
- link to the new page from dashboard header
- route `/embeds` in `App.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856289919548320b052f0a1b69badc2