### PR TITLE
Update hero image to show embedder features

### DIFF
--- a/public/shorts-array.svg
+++ b/public/shorts-array.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400" fill="none">
+  <rect width="800" height="400" rx="20" fill="#f3f4f6"/>
+  <g transform="translate(100,60)">
+    <rect x="0" y="0" width="120" height="220" rx="10" fill="#fff" stroke="#d1d5db" stroke-width="4"/>
+    <polygon points="40,100 80,120 40,140" fill="#d1d5db"/>
+  </g>
+  <g transform="translate(250,60)">
+    <rect x="0" y="0" width="120" height="220" rx="10" fill="#fff" stroke="#d1d5db" stroke-width="4"/>
+    <polygon points="40,100 80,120 40,140" fill="#d1d5db"/>
+  </g>
+  <g transform="translate(400,60)">
+    <rect x="0" y="0" width="120" height="220" rx="10" fill="#fff" stroke="#d1d5db" stroke-width="4"/>
+    <polygon points="40,100 80,120 40,140" fill="#d1d5db"/>
+  </g>
+  <text x="400" y="330" text-anchor="middle" font-size="24" fill="#6b7280">Embed Short Videos Anywhere</text>
+</svg>

--- a/src/components/ui/hero-section-1.tsx
+++ b/src/components/ui/hero-section-1.tsx
@@ -173,17 +173,17 @@ export function HeroSection() {
                                 <div className="inset-shadow-2xs ring-background dark:inset-shadow-white/20 bg-background relative mx-auto max-w-6xl overflow-hidden rounded-2xl border p-4 shadow-lg shadow-zinc-950/15 ring-1">
                                     <img
                                         className="bg-background aspect-15/8 relative hidden rounded-2xl dark:block"
-                                        src="https://tailark.com//_next/image?url=%2Fmail2.png&w=3840&q=75"
-                                        alt="app screen"
-                                        width="2700"
-                                        height="1440"
+                                        src="/shorts-array.svg"
+                                        alt="embedder preview"
+                                        width="800"
+                                        height="400"
                                     />
                                     <img
                                         className="z-2 border-border/25 aspect-15/8 relative rounded-2xl border dark:hidden"
-                                        src="https://tailark.com/_next/image?url=%2Fmail2-light.png&w=3840&q=75"
-                                        alt="app screen"
-                                        width="2700"
-                                        height="1440"
+                                        src="/shorts-array.svg"
+                                        alt="embedder preview"
+                                        width="800"
+                                        height="400"
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add a new placeholder illustration of embedded shorts
- use the new image in the hero component

## Testing
- `npm run lint` *(fails: `A require() style import is forbidden` and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856c9396c308320bb47ca906211eb73