### PR TITLE
Clip video content in embed preview

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -38,15 +38,17 @@ const Dashboard = () => {
 
     if (platform === "youtube") {
       html = `<div style="display:flex;justify-content:${justify};width:100%;">
-  <iframe
-    width="${width[0]}"
-    height="${height[0]}"
-    src="https://www.youtube.com/embed/${id}?autoplay=${autoplayParam}&controls=${controlsParam}&modestbranding=1&rel=0&playsinline=1&fs=0"
-    title="YouTube video player"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen>
-  </iframe>
+  <div style="overflow:hidden;width:${width[0]}px;height:${height[0]}px;">
+    <iframe
+      width="100%"
+      height="100%"
+      src="https://www.youtube.com/embed/${id}?autoplay=${autoplayParam}&controls=${controlsParam}&modestbranding=1&rel=0&playsinline=1&fs=0"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </div>
 </div>`;
     } else if (platform === "tiktok") {
       html = `<div style="display:flex;justify-content:${justify};width:100%;">
@@ -146,15 +148,17 @@ const Dashboard = () => {
         const autoplayParam = autoplay ? "1" : "0";
         const controlsParam = controls ? "1" : "0";
         return (
-          <iframe
-            width={width[0]}
-            height={height[0]}
-            src={`https://www.youtube.com/embed/${previewVideoId}?autoplay=${autoplayParam}&controls=${controlsParam}&modestbranding=1&rel=0&playsinline=1&fs=0`}
-            title="YouTube video player"
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          />
+          <div style={{ width: width[0], height: height[0], overflow: "hidden" }}>
+            <iframe
+              width="100%"
+              height="100%"
+              src={`https://www.youtube.com/embed/${previewVideoId}?autoplay=${autoplayParam}&controls=${controlsParam}&modestbranding=1&rel=0&playsinline=1&fs=0`}
+              title="YouTube video player"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
         );
       }
 
@@ -199,6 +203,7 @@ const Dashboard = () => {
       <div style={{ display: "flex", justifyContent, width: "100%" }}>
         <Rnd
           size={{ width: width[0], height: height[0] }}
+          style={{ overflow: "hidden" }}
           onDragStop={(_, d) => {
             // position is handled via flex, so just ignore drag values
           }}


### PR DESCRIPTION
## Summary
- wrap preview iframe in an overflow-hidden container so resizing crops only the video
- apply the same wrapper to generated embed markup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c8c5ca6c83209740616754f1aba3