### PR TITLE
Fix preview background crop

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -149,7 +149,14 @@ const Dashboard = () => {
       const iframeWidth = height * (16 / 9); // Calculate width to maintain 16:9 aspect ratio for the iframe
 
       return (
-        <div style={{ width: '100%', height: '100%', overflow: 'hidden', position: 'relative', background: '#000' }}>
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            overflow: "hidden",
+            position: "relative",
+          }}
+        >
           <iframe
             src={`https://www.youtube.com/embed/${previewVideoId}?autoplay=${autoplayParam}&controls=${controlsParam}&showinfo=0&rel=0&modestbranding=1`}
             style={{


### PR DESCRIPTION
## Summary
- remove black background from YouTube preview container so only the short is clipped

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856cb803acc83209f598750fea56d7b