### PR TITLE
Update embed workflow

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -41,6 +41,7 @@ const Dashboard = () => {
   const [copied, setCopied] = useState(false);
   const [embedCount, setEmbedCount] = useState(3);
   const [showPreview, setShowPreview] = useState(false);
+  const [showCode, setShowCode] = useState(false);
   const [previewPlatform, setPreviewPlatform] = useState("");
   const [previewVideoId, setPreviewVideoId] = useState("");
 
@@ -55,18 +56,17 @@ const Dashboard = () => {
   
   useEffect(() => {
     if (!showPreview) return;
-    generateEmbedCode(false); // Regenerate code on settings change, but don't increment count
 
     if (previewPlatform === "instagram") {
       window.instgrm?.Embeds.process();
     }
-    if (previewPlatform === 'tiktok') {
+    if (previewPlatform === "tiktok") {
       window.tiktok?.embed.render();
     }
-  }, [width, height, position, autoplay, controls]);
+  }, [width, height, position, autoplay, controls, showPreview, previewPlatform]);
 
 
-  const generateEmbedCode = (isNew = true) => {
+  const generateEmbedCode = (isNew = true, save = true) => {
     if (!videoUrl && isNew) return;
 
     let videoId = previewVideoId;
@@ -102,7 +102,7 @@ const Dashboard = () => {
       setPreviewPlatform(platform);
       setPreviewVideoId(videoId);
       setShowPreview(true);
-      if(isNew) setEmbedCount(prev => prev + 1);
+      if (isNew && save) setEmbedCount(prev => prev + 1);
     }
 
     let html = "";
@@ -123,7 +123,7 @@ const Dashboard = () => {
 
     setEmbedCode(html);
     
-    if (isNew) {
+    if (save) {
       try {
         const stored = JSON.parse(localStorage.getItem("embeds") || "[]");
         stored.unshift({ url: videoUrl, code: html, date: new Date().toISOString() });
@@ -138,6 +138,16 @@ const Dashboard = () => {
     navigator.clipboard.writeText(embedCode);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleGenerate = () => {
+    if (!showPreview) {
+      generateEmbedCode(true, false);
+      setShowCode(false);
+    } else {
+      generateEmbedCode(false, true);
+      setShowCode(true);
+    }
   };
 
   const renderPreview = () => {
@@ -296,7 +306,7 @@ const Dashboard = () => {
               </div>
             </div>
             
-            <Button onClick={() => generateEmbedCode(true)} className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:opacity-90 transition-opacity flex items-center gap-2">
+            <Button onClick={handleGenerate} className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:opacity-90 transition-opacity flex items-center gap-2">
               Generate Embed <MoveRight className="w-4 h-4" />
             </Button>
           </aside>
@@ -329,7 +339,7 @@ const Dashboard = () => {
                   )}
               </div>
 
-              {showPreview && (
+              {showCode && (
                   <div className="mt-6">
                     <div className="flex justify-between items-center mb-2">
                       <h3 className="text-lg font-semibold flex items-center gap-2"><Code className="w-5 h-5"/>Embed Code</h3>


### PR DESCRIPTION
## Summary
- add `showCode` state to control when embed code is shown
- defer saving embed until user clicks **Generate Embed** again
- update button handler so users can preview first and then generate code

## Testing
- `npm run build:dev`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6856cb7516808320bbbab118f7a05c5f