### PR TITLE
Adjust Auth button color and autofill

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,12 @@
     @apply bg-clip-text text-transparent bg-gradient-to-b from-foreground via-foreground/90 to-muted-foreground;
   }
 }
+
+/* Ensure consistent autofill styling for inputs */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  box-shadow: 0 0 0 1000px rgba(23,23,23,0.5) inset;
+  -webkit-text-fill-color: #fff;
+  font: inherit;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -348,7 +348,7 @@ export const AuthPage = ({ className, mode }: SignInPageProps) => {
                   <button
                     type="submit"
                     disabled={isSubmitting}
-                    className="w-full text-white py-3 px-4 rounded-full bg-cyan-600 hover:bg-cyan-700 disabled:bg-cyan-800/50 disabled:cursor-not-allowed transition-colors font-semibold"
+                    className="w-full text-black py-3 px-4 rounded-full bg-white hover:bg-neutral-200 disabled:bg-neutral-400/50 disabled:text-neutral-700 disabled:cursor-not-allowed transition-colors font-semibold"
                   >
                     {isSubmitting ? 'Processing...' : (mode === 'signin' ? 'Sign In' : 'Create Account')}
                   </button>


### PR DESCRIPTION
## Summary
- change login/signup button background from cyan to white
- keep fonts and colors during browser autofill

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build` *(fails: tsconfig references require composite true)*

------
https://chatgpt.com/codex/tasks/task_e_685b1e91189483208032f448356fe5f5