### PR TITLE
Fix FAQ link

### DIFF
--- a/src/components/ui/hero-section-1.tsx
+++ b/src/components/ui/hero-section-1.tsx
@@ -277,7 +277,7 @@ function HeroHeader() {
                         Pricing
                     </a>
                     <a
-                        href="#faq"
+                        href="/pricing#faq"
                         className="text-muted-foreground hover:text-foreground text-sm">
                         FAQ
                     </a>
@@ -325,7 +325,7 @@ function HeroHeader() {
                                 Pricing
                             </a>
                             <a
-                                href="#faq"
+                                href="/pricing#faq"
                                 className="text-muted-foreground hover:text-foreground text-sm">
                                 FAQ
                             </a>


### PR DESCRIPTION
## Summary
- ensure the header FAQ link navigates to the pricing FAQ section

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build` *(fails: tsconfig referenced project must have setting composite true)*

------
https://chatgpt.com/codex/tasks/task_e_685b39a96e38832088f0cc47958c28d8